### PR TITLE
CLJ2116: Support for selective conforming with clojure.spec

### DIFF
--- a/src/main/clojure/clojure/spec/alpha.clj
+++ b/src/main/clojure/clojure/spec/alpha.clj
@@ -151,7 +151,12 @@
   ([spec x cc]
    (conform spec x cc true))
   ([spec x cc specize?]
-   (conform* (if specize? (specize spec) spec) x cc)))
+   (let [spec' (if specize? (specize spec) spec)]
+     (if-let [cf (if cc (cc spec))]
+       (let [conformed (cf spec' x cc)]
+         (c/or (c/and (= ::invalid conformed) conformed)
+               (conform* spec' conformed cc)))
+       (conform* spec' x cc)))))
 
 (defn unform
   "Given a spec and a value created by or compliant with a call to
@@ -198,6 +203,7 @@
       (assoc spec ::gfn gen-fn)
       (with-gen* (specize spec) gen-fn))))
 
+;; TODO: copy impl from spec-tools
 (defn explain-data* [spec path via in x cc]
   (let [probs (explain* (specize spec) path via in x cc)]
     (when-not (empty? probs)

--- a/src/test/clojure/clojure/test_clojure/spec.clj
+++ b/src/test/clojure/clojure/test_clojure/spec.clj
@@ -215,6 +215,28 @@
     [{10 10 20 "x"}]
     [{10 10 20 "x"}]))
 
+(deftest conforming-callback-test
+  (let [string->int-conforming
+        (fn [spec]
+          (condp = spec
+            int? (fn [_ x _]
+                   (cond
+                     (int? x) x
+                     (string? x) (try
+                                   (Long/parseLong x)
+                                   (catch Exception _
+                                     ::s/invalid))
+                     :else ::s/invalid))
+            :else nil))]
+
+    (testing "no conforming callback"
+      (is (= 1 (s/conform int? 1)))
+      (is (= ::s/invalid (s/conform int? "1"))))
+
+    (testing "with conforming callback"
+      (is (= 1 (s/conform int? 1 string->int-conforming)))
+      (is (= 1 (s/conform int? "1" string->int-conforming))))))
+
 (comment
   (require '[clojure.test :refer (run-tests)])
   (in-ns 'clojure.test-clojure.spec)


### PR DESCRIPTION
## THIS IS A DUMMY PR for discussion purposes, will create a patch via Jira is gets further.

# What

Support separation of `conform` from Specs, allowing different conforming to be run for same specs at runtime. 

This is already implemented in [spec-tools](https://github.com/metosin/spec-tools), but it needs to use Dynamic Binding and wrap specs into Spec Records to make this work.

# Why

Allows Specs to be used as a runtime transformation engine, main use cases being the Web: sending and receiving Spec'd data over different formats (String, JSON, Transit) without needing to write manually differently conforming specs for all combinations.

# How

* Add a extra argument `cc` (conforming callback) to:
  *  `conform*`, `explain*`, `conform`, `explain`, `explain-data` and `explain-str`: all support the old arities, causing `cc` to be set to `nil`
   * **BREAKING**: `conform*` and `explain*` always have the extra parameter, passed on to internal spec functions
   * if `cc` is set in `conform`, it is called with a `spec` argument. It should return either `nil` (default case, run conform as before) or a anonymous `conform*` function, which is used to pre-conform the value before passing it to normal conform
   * **BREAKING**: all calls to to subspecs `conform*` from `conform* need to be called via top-level `conform` - which has a perf optimized arity for this.

# Todo

* [ ] Support also runtime conforming `explain` 
* [ ] Fix docs
* [ ] More tests

# Notes

The actual supporting converters (string->long, string->keyword) and `Conforming Callback` could  be hosted in non-core project like in [spec-tools](https://github.com/metosin/spec-tools) to enable moving fast - and supporting both clj & cljs.

# Example

```clj
(deftest conforming-callback-test
  (let [string->int-conforming
        (fn [spec]
          (condp = spec
            int? (fn [_ x _]
                   (cond
                     (int? x) x
                     (string? x) (try
                                   (Long/parseLong x)
                                   (catch Exception _
                                     ::s/invalid))
                     :else ::s/invalid))
            :else nil))]

    (testing "no conforming callback"
      (is (= 1 (s/conform int? 1)))
      (is (= ::s/invalid (s/conform int? "1"))))

    (testing "with conforming callback"
      (is (= 1 (s/conform int? 1 string->int-conforming)))
      (is (= 1 (s/conform int? "1" string->int-conforming))))))
```

